### PR TITLE
RUN-1659: Add release workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+name-template: "v$NEXT_PATCH_VERSION 🎉"
+tag-template: "v$NEXT_PATCH_VERSION"
+change-template: "* $TITLE (#$NUMBER) @$AUTHOR"
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,16 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-draft-release:
+    if: !startsWith(github.event.head_commit.message, '[no-release-draft]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,49 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the project
+        run: npm run build
+
+      - name: Configure git
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Update package.json version
+        run: |
+          # get version from tag and update package.json
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "Setting version in package.json to ${VERSION}"
+          npm version ${VERSION} --no-git-tag-version 
+
+          # push to main
+          git add package.json
+          git commit -m "[no-release-draft] Update package.json to version ${VERSION}"
+          git push origin main
+
+          # move tag to HEAD
+          git push --force origin "HEAD:refs/tags/${VERSION}"
+          git fetch --tags
+
+      - name: Publish to Github Packages
+        run: npm publish
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Run tests
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main # This branch can only be pushed to via PRs, which would have run tests already
 
 jobs:
   test:

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 package-lock=false
 audit-level=critical
+
+@rvshare:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A service for server-side rendering your JavaScript views",
   "main": "lib/index.js",
   "scripts": {
-    "prepare": "npm run build",
     "clean": "rimraf lib",
     "prebuild": "npm run clean",
     "build": "babel src -d lib",
@@ -20,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:airbnb/hypernova.git"
+    "url": "git@github.com:rvshare/hypernova.git"
   },
   "keywords": [
     "react",
@@ -41,9 +40,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/airbnb/hypernova/issues"
+    "url": "https://github.com/rvshare/hypernova/issues"
   },
-  "homepage": "https://github.com/airbnb/hypernova",
+  "homepage": "https://github.com/rvshare/hypernova",
   "devDependencies": {
     "@babel/cli": "^7.25.9",
     "@babel/core": "^7.26.0",

--- a/src/environment.js
+++ b/src/environment.js
@@ -8,7 +8,7 @@ const promiseShimsEnvKey = 'HYPERNOVA_PROMISE_SHIMS';
 const shouldShimPromise = envIsTrue(process.env[promiseShimsEnvKey]);
 
 const es6methods = ['then', 'catch', 'constructor', 'finally'];
-const es6StaticMethods = ['all', 'allSettled', 'any', 'race', 'resolve', 'reject', 'cast', 'try', 'withResolvers'];
+const es6StaticMethods = ['all', 'allSettled', 'any', 'race', 'resolve', 'reject', 'cast', 'try', 'withResolvers', 'isRejected'];
 
 function isNotMethod(name) {
   return !(es6methods.includes(name) || es6StaticMethods.includes(name) || name.charAt(0) === '_');


### PR DESCRIPTION
- Use release-drafter to draft releases on pushes to main similar to marketplace
- On release publish, update the version in package.json and publish to github packages
- Don't run tests on main (redundant)
- Update .npmrc to use rvshare's github packages registry
- Sneak in a `Promise.isRejected` polyfill allowlist item
- Update URLS in package.json and remove `prepare`