### PR TITLE
RUN-1659: Use github packages for releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+name-template: "v$NEXT_PATCH_VERSION 🎉"
+tag-template: "v$NEXT_PATCH_VERSION"
+change-template: "* $TITLE (#$NUMBER) @$AUTHOR"
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,35 @@
+name: Draft Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Matches tags starting with "v"
+
+jobs:
+  update-draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Ensure tag is on main branch
+        run: |
+          main_commit=$(git rev-parse main)
+          echo "Main branch commit: $main_commit"
+          echo "Head commit: ${{ github.sha }}"
+          if [[ "${{ github.sha }}" != "$main_commit" ]]; then
+            echo "Commit does not match main branch. Exiting."
+            exit 1
+          fi
+
+      - name: Get version from tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ env.VERSION }}
+          tag: ${{ env.VERSION }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,25 +1,29 @@
-name: Run tests
+name: Publish Release
 
 on:
-  push:
-    branches-ignore:
-      - main # This branch can only be pushed to via PRs, which would have run tests already
+  release:
+    types: [published]
+
+permissions:
+  contents: write
 
 jobs:
-  test:
+  publish-release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Install dependencies
         run: npm install
+
+      - name: Build the project
+        run: npm run build
 
       - name: Lint
         run: npm run lint
@@ -32,3 +36,9 @@ jobs:
         with:
           name: coverage-report
           path: ./coverage
+
+      - name: Publish to Github Packages
+        run: npm publish
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 package-lock=false
 audit-level=critical
+
+@rvshare:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.6.0] - 2024-12-19
+
+- Set minimum node version to 18
+- Update/remove deps to fix vulnerabilities (currently 0!)
+- Update npm scripts
+  - Add easy test commands
+  - Transpile tests on-demand so that they can be written against source code instead of dist code
+- Conditionally remove Promise shim (HYPERNOVA_PROMISE_SHIMS env var)
+  - Also conditionally log performance metrics around this (HYPERNOVA_PROFILING env var)
+- Add/update tests
+  - Add escape hatch to shut servers off so they don't persist after their test is done
+- Use simple test workflow
+- Add release command and workflows
+
 ## [2.5.0] - 2019-01-02
 
 ### Added

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,11 @@
+# Development
+
+## Releasing
+
+Once the `main` branch is in a state that you would like to cut a release from, you can do the following:
+
+1. Checkout `main` locally and ensure you have no local changes.
+2. Run `npm run release` - This will prompt for a new version number, update `package.json`, generate a tagged commit, and push it, triggering the `draft-release` workflow.
+3. Review the draft release at https://github.com/rvshare/hypernova/releases (you may need to wait a minute for it to show up). Once it's to your liking, go ahead and publish it. This will kick off the `publish-release` workflow, which will publish the build to Github Packages.
+
+After releasing, you'll likely want to update the version accordingly in `rvshare-marketplace`.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The inverse of `toScript`, this function runs on the browser and attempts to fin
 The `serialize` function uses the attributes `DATA_KEY` and `DATA_ID` to generate the data markup. They can be used in the `fromScript` function to get the serialized data.
 
 ```typescript
-import { DATA_KEY, DATA_ID } from 'hypernova'
+import { DATA_KEY, DATA_ID } from '@rvshare/hypernova'
 
 fromScript({
     [DATA_KEY]: key,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "hypernova",
+  "name": "@rvshare/hypernova",
   "version": "2.5.0",
   "description": "A service for server-side rendering your JavaScript views",
   "main": "lib/index.js",
   "scripts": {
-    "prepare": "npm run build",
     "clean": "rimraf lib",
     "prebuild": "npm run clean",
     "build": "babel src -d lib",
@@ -16,11 +15,12 @@
     "test:files": "mocha --require @babel/register test/init.js",
     "test:files:help": "echo 'Use like npm run test:files -- test/my-test.js test/my-other-test.js'",
     "test:quick": "npm run test:files -- test/*-test.js -R dots",
-    "test:ci": "npm run coverage -- -R spec"
+    "test:ci": "npm run coverage -- -R spec",
+    "release": "yarn version && git push && git push --tags && echo \"A release will be drafted at https://github.com/rvshare/hypernova/releases. Publish it to complete the release.\""
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:airbnb/hypernova.git"
+    "url": "git+ssh://git@github.com/rvshare/hypernova.git"
   },
   "keywords": [
     "react",
@@ -41,9 +41,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/airbnb/hypernova/issues"
+    "url": "https://github.com/rvshare/hypernova/issues"
   },
-  "homepage": "https://github.com/airbnb/hypernova",
+  "homepage": "https://github.com/rvshare/hypernova",
   "devDependencies": {
     "@babel/cli": "^7.25.9",
     "@babel/core": "^7.26.0",

--- a/src/environment.js
+++ b/src/environment.js
@@ -8,7 +8,7 @@ const promiseShimsEnvKey = 'HYPERNOVA_PROMISE_SHIMS';
 const shouldShimPromise = envIsTrue(process.env[promiseShimsEnvKey]);
 
 const es6methods = ['then', 'catch', 'constructor', 'finally'];
-const es6StaticMethods = ['all', 'allSettled', 'any', 'race', 'resolve', 'reject', 'cast', 'try', 'withResolvers'];
+const es6StaticMethods = ['all', 'allSettled', 'any', 'race', 'resolve', 'reject', 'cast', 'try', 'withResolvers', 'isRejected'];
 
 function isNotMethod(name) {
   return !(es6methods.includes(name) || es6StaticMethods.includes(name) || name.charAt(0) === '_');


### PR DESCRIPTION
- Add draft-release workflow to draft releases when a tag matching /v*/ is pushed to the HEAD of main
  - Use release-drafter similar to other rvshare repos
- Add publish-release workflow to publish to Github Packages when a release is published
- Update tests workflow not to run on main
- Update .npmrc with rvshare registry info
- Update CHANGELOG.md
- Create DEVELOPMENT.md to describe how to cut a release
- Update package.json to point to rvshare repo, use @rvshare prefix, add release command, and remove prepare command
- Update README.md to use new package name
- (misc) Add `isRejected` to promise polyfill